### PR TITLE
chore: update CD pipeline to build and push Docker image to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,13 @@ jobs:
           pytest tests/ -v
 
       - name: Build Docker image
-        run: docker build -t ai-study-buddy .
+        run: docker build -t cipher974/ai-study-buddy .
 
       - name: Smoke test
         run: |
           docker run -d -p 5000:5000 \
             -e MONGODB_URI="${{ secrets.MONGODB_URI }}" \
-            --name test-container ai-study-buddy
+            --name test-container cipher974/ai-study-buddy
           sleep 10
           docker logs test-container
           curl --fail http://localhost:5000/health
@@ -54,6 +54,22 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image to Docker Hub
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: cipher974/ai-study-buddy:latest
+
       - name: Trigger Render deployment
         run: |
           curl --fail "${{ secrets.RENDER_DEPLOY_URL }}"


### PR DESCRIPTION
## What this PR does
- Updates CD job to log into Docker Hub using secrets
- Adds build and push step to push image to 
  cipher974/ai-study-buddy:latest on Docker Hub
- Keeps Render deploy hook trigger after image push
- Render will now pull latest image from Docker Hub
  instead of building from source

## Flow After This PR
Push to main
→ CI runs (linter, tests, Docker build, smoke test)
→ CI passes
→ CD runs:
   1. Logs into Docker Hub
   2. Builds and pushes image to Docker Hub
   3. Calls Render deploy hook
→ Render pulls cipher974/ai-study-buddy:latest
→ Live URL updates

## How to Test
1. Merge this PR to main
2. Go to Actions tab:
   - CI job should go green
   - CD job should go green after CI
3. Go to https://hub.docker.com/r/cipher974/ai-study-buddy
   - Latest image should appear
4. Go to Render dashboard
   - New deployment should be triggered
5. Refresh live URL
   - Latest changes should be visible

## Expected Result
- Both CI and CD jobs green
- Image visible on Docker Hub
- Render deploys successfully
- Live URL updated

## Closes #31