### PR TITLE
fix: standardize MongoDB env variable name to MONGODB_URI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,4 @@ FLASK_ENV=development
 FLASK_DEBUG=1
 SECRET_KEY=your-secret-key-here
 GEMINI_API_KEY=your-gemini-api-key-here
-MONGO_URI=your-mongodb-connection-string-here
+MONGODB_URI=your-mongodb-connection-string-here

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 @pytest.fixture
 def client(monkeypatch):
-    monkeypatch.setenv('MONGO_URI', 'mongodb://localhost:27017/')
+    monkeypatch.setenv('MONGODB_URI', 'mongodb://localhost:27017/')
     import mongomock
     monkeypatch.setattr('pymongo.MongoClient', mongomock.MongoClient)
     import app as flask_app


### PR DESCRIPTION
## What this PR does
- Updates .env.example from MONGO_URI to MONGODB_URI
- Updates tests/test_app.py fixture to patch 
  MONGODB_URI instead of MONGO_URI
- Standardizes MongoDB variable name across all 
  files to match Render and GitHub secrets config

## Why this is needed
app.py reads MONGODB_URI but .env.example and tests 
referenced MONGO_URI causing a mismatch. This could 
cause silent MongoDB connection failures on any 
deployment where the wrong variable name is set.

## Files changed
- .env.example
- tests/test_app.py

## How to Test
1. Pull this branch
2. Run tests:
   pytest tests/ -v
   Expected: 12 tests passing
3. Check CI goes green on GitHub Actions
4. Verify .env.example shows MONGODB_URI
5. Verify test fixture patches MONGODB_URI

## Expected Result
- All 12 tests pass
- CI pipeline green
- Variable name consistent across all files

## Closes #36 